### PR TITLE
Fixing #37 and partially also #38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 src/*.o
 src/*.so
 src/*.dll
+src/Makevars
 Notes.txt
 Meta
 .Rproj.user
+.DS_Store
+config.log
+config.status

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes in version 1.1.3
+    
+  Bug fixes
+    -doubleGenome, mergeGenome, and reduceGenome should now really work with pedigree and recombination tracking
+
 Changes in version 1.1.2
     
   Bug fixes

--- a/R/polyploids.R
+++ b/R/polyploids.R
@@ -242,8 +242,10 @@ mergeGenome = function(females,males,crossPlan,simParam=NULL){
      (min(crossPlan)<1L)){
     stop("Invalid crossPlan")
   }
-  mother = as.integer(females@id[crossPlan[,1]])
-  father = as.integer(males@id[crossPlan[,2]])
+  mother = females@id[crossPlan[,1]]
+  father = males@id[crossPlan[,2]]
+  iMother = as.integer(mother)
+  iFather = as.integer(father)
   # Merge genotype data
   geno = vector("list", females@nChr)
   for(i in 1:females@nChr){
@@ -279,21 +281,27 @@ mergeGenome = function(females,males,crossPlan,simParam=NULL){
         for(l in 1:females@ploidy){
           k = k+1
           newHist[[i]][[j]][[k]] = 
-            oldHist[[mother[i]]][[j]][[l]]
+            oldHist[[iMother[i]]][[j]][[l]]
         }
         for(l in 1:males@ploidy){
           k = k+1
           newHist[[i]][[j]][[k]] = 
-            oldHist[[father[i]]][[j]][[l]]
+            oldHist[[iFather[i]]][[j]][[l]]
         }
       }
     }
-    simParam$addToRec(newHist)
+  }else{
+    newHist = NULL
   }
   return(newPop(rawPop=rPop,
                 mother=mother,
                 father=father,
+                simParam=simParam,
                 isDH=FALSE,
-                simParam=simParam))
+                iMother=iMother,
+                iFather=iFather,
+                femaleParentPop=females,
+                maleParentPop=males,
+                hist=newHist))
 }
 

--- a/R/polyploids.R
+++ b/R/polyploids.R
@@ -173,7 +173,9 @@ doubleGenome = function(pop, keepParents=TRUE,
           for(m in 1:2){
             k = k+1
             newHist[[i]][[j]][[k]] = 
-              oldHist[[as.numeric(id[i])]][[j]][[l]]
+              oldHist[[id[i]]][[j]][[l]]
+            # the above works because when simParam$isTrackRec is set, we also
+            # have simParam$isTrackPed set, and hence we have id
           }
         }
       }

--- a/R/polyploids.R
+++ b/R/polyploids.R
@@ -79,8 +79,9 @@ reduceGenome = function(pop,nProgeny=1,useFemale=TRUE,keepParents=TRUE,
                   mother=rep(pop@mother,each=nProgeny),
                   father=rep(pop@father,each=nProgeny),
                   simParam=simParam,
-                  iMother=rep(pop@iid,each=nProgeny),
-                  iFather=rep(pop@iid,each=nProgeny),
+                  isDH=FALSE,
+                  iMother=rep(as.integer(pop@mother),each=nProgeny),
+                  iFather=rep(as.integer(pop@father),each=nProgeny),
                   femaleParentPop=pop,
                   maleParentPop=pop,
                   hist=hist
@@ -90,6 +91,7 @@ reduceGenome = function(pop,nProgeny=1,useFemale=TRUE,keepParents=TRUE,
                   mother=rep(pop@id,each=nProgeny),
                   father=rep(pop@id,each=nProgeny),
                   simParam=simParam,
+                  isDH=FALSE,
                   iMother=rep(pop@iid,each=nProgeny),
                   iFather=rep(pop@iid,each=nProgeny),
                   femaleParentPop=pop,
@@ -152,7 +154,7 @@ doubleGenome = function(pop, keepParents=TRUE,
   if(simParam$isTrackPed){
     # Extract actual parents
     ped = simParam$ped
-    id = as.numeric(pop@id)
+    id = as.integer(pop@id)
     mother = ped[id,1]
     father = ped[id,2]
   }else{
@@ -188,8 +190,8 @@ doubleGenome = function(pop, keepParents=TRUE,
                 father=origF,
                 simParam=simParam,
                 isDH=TRUE,
-                iMother=pop@iid,
-                iFather=pop@iid,
+                iMother=as.integer(origM),
+                iFather=as.integer(origF),
                 femaleParentPop=pop,
                 maleParentPop=pop,
                 hist=newHist))

--- a/R/polyploids.R
+++ b/R/polyploids.R
@@ -154,9 +154,9 @@ doubleGenome = function(pop, keepParents=TRUE,
   if(simParam$isTrackPed){
     # Extract actual parents
     ped = simParam$ped
-    id = as.integer(pop@id)
-    mother = ped[id,1]
-    father = ped[id,2]
+    iid = as.integer(pop@id)
+    mother = ped[iid,1]
+    father = ped[iid,2]
   }else{
     # Provide arbitrary parents (not actually used)
     mother = origM
@@ -175,7 +175,7 @@ doubleGenome = function(pop, keepParents=TRUE,
           for(m in 1:2){
             k = k+1
             newHist[[i]][[j]][[k]] = 
-              oldHist[[id[i]]][[j]][[l]]
+              oldHist[[iid[i]]][[j]][[l]]
             # the above works because when simParam$isTrackRec is set, we also
             # have simParam$isTrackPed set, and hence we have id
           }


### PR DESCRIPTION
These changes should address #37 as well as partially #38. I show below that they now output the appropriate pedigree (I have not checked recombinations though!), but I would appreciate code check to be on the safe side @gaynorr 

```
library(AlphaSimR)
founderGenomes <- quickHaplo(nInd = 3, nChr = 1, segSites = 100)
SP <- SimParam$new(founderGenomes)
SP$setTrackPed(TRUE)
basePop <- newPop(founderGenomes)
x1 <- reduceGenome(basePop[1], nProgeny = 10)
basePop[1]@id
# [1] "1"
basePop[1]@father
# [1] "0"
basePop[1]@mother
# [1] "0"
x1@iid
# [1]  4  5  6  7  8  9 10 11 12 13
x1@id
# [1] "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13"
x1@mother
# [1] "0" "0" "0" "0" "0" "0" "0" "0" "0" "0"
x1@father
# [1] "0" "0" "0" "0" "0" "0" "0" "0" "0" "0"
x1@ploidy
# [1] 1
SP$pedigree
# mother father isDH
# 1       0      0    0
# 2       0      0    0
# 3       0      0    0
# 4       0      0    0
# 5       0      0    0
# 6       0      0    0
# 7       0      0    0
# 8       0      0    0
# 9       0      0    0
# 10      0      0    0
# 11      0      0    0
# 12      0      0    0
# 13      0      0    0

pop = randCross(basePop, nCrosses = 3, nProgeny = 2)
pop@iid
# [1]  14 15 16 17 18 19
pop@id
# [1] "14" "15" "16" "17" "18" "19"
pop@mother
# [1] "1" "1" "1" "1" "2" "2"
pop@father
# [1] "2" "2" "3" "3" "3" "3"
pop@ploidy
# [1] 2
SP$pedigree
# mother father isDH
# ...
# 14      1      2    0
# 15      1      2    0
# 16      1      3    0
# 17      1      3    0
# 18      2      3    0
# 19      2      3    0

x2 <- reduceGenome(pop[1], nProgeny = 5)
pop[1]@id
# [1] "14"
pop[1]@father
# [1] "2"
pop[1]@mother
# [1] "1"
x2@iid
# [1]  20 21 22 23 24
x2@id
# [1] "20" "21" "22" "23" "24"
x2@mother
# [1] "1" "1" "1" "1" "1"
x2@father
# [1] "2" "2" "2" "2" "2"
x2@ploidy
# [1] 1
SP$pedigree
# mother father isDH
# ...
# 20      1      2    0
# 21      1      2    0
# 22      1      2    0
# 23      1      2    0
# 24      1      2    0

x3 <- reduceGenome(pop[1], nProgeny = 5, keepParents = FALSE)
pop[1]@id
# [1] "14"
pop[1]@father
# [1] "2"
pop[1]@mother
# [1] "1"
x3@iid
# [1] 25 26 27 28 29
x3@id
# [1] "25" "26" "27" "28" "29"
x3@mother
# [1] "14" "14" "14" "14" "14"
x3@father
# [1] "14" "14" "14" "14" "14"
x3@ploidy
# [1] 1
SP$pedigree
# ...
# 25     14     14    0
# 26     14     14    0
# 27     14     14    0
# 28     14     14    0
# 29     14     14    0

y1 <- mergeGenome(x1, x1, crossPlan = cbind(x1@id, x1@id))
x1@id
# "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13"
y1@id
# [1] "30" "31" "32" "33" "34" "35" "36" "37" "38" "39"
y1@mother
# [1]  "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13"
y1@father
# [1] "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13"
y1@ploidy
# [1] 2
SP$pedigree
# ...
# 30      4      4    0
# 31      5      5    0
# 32      6      6    0
# 33      7      7    0
# 34      8      8    0
# 35      9      9    0
# 36     10     10    0
# 37     11     11    0
# 38     12     12    0
# 39     13     13    0

y2 <- mergeGenome(x2, x2, crossPlan = cbind(x2@id, x2@id))
x2@id
# "20" "21" "22" "23" "24"
y2@id
# [1] "40" "41" "42" "43" "44"
y2@mother
# [1]  "20" "21" "22" "23" "24"
y2@father
# [1] "20" "21" "22" "23" "24"
y2@ploidy
# [1] 2
SP$pedigree
# ...
# 40     20     20    0
# 41     21     21    0
# 42     22     22    0
# 43     23     23    0
# 44     24     24    0

y3 <- mergeGenome(x3, x3, crossPlan = cbind(x3@id, x3@id))
x3@id
# "25" "26" "27" "28" "29"
y3@id
# [1] "45" "46" "47" "48" "49"
y3@mother
# [1]  "25" "26" "27" "28" "29"
y3@father
# [1] "25" "26" "27" "28" "29"
y3@ploidy
# [1] 2
SP$pedigree
# ...
# 45     25     25    0
# 46     26     26    0
# 47     27     27    0
# 48     28     28    0
# 49     29     29    0
```