### PR TITLE
Updated example for makeCross function

### DIFF
--- a/R/crossing.R
+++ b/R/crossing.R
@@ -291,7 +291,7 @@ selectCross = function(pop,nInd=NULL,nFemale=NULL,nMale=NULL,nCrosses,
 #' pop = newPop(founderPop, simParam=SP)
 #'
 #' #Cross individual 1 with individual 10
-#' crossPlan = matrix(c(1,10), nrow=1, ncol=2)
+#' crossPlan = matrix(c("1","10"), nrow=1, ncol=2)
 #' pop2 = makeCross2(pop, pop, crossPlan, simParam=SP)
 #'
 #' @export


### PR DESCRIPTION
- Improved the example in the documentation for makeCross to make it more general.
- ids are now supplied as characters in the crossPlan rather than as integer values. 
- This handles situations where the position of an individual in pop@id does not align with their id value.