### PR TITLE
Warn when misc lists don't match in c(pop, pop2) #244

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 *changed `popVar` to an R wrapper to automate casting of vectors to matrices
 
+*warn when misc lists don't match in length or names in `c(pop, pop2)`
+
 # AlphaSimR 2.0.0
 
 *added names to `SP$recHist`

--- a/R/mergePops.R
+++ b/R/mergePops.R
@@ -1,3 +1,5 @@
+# fmt: skip file
+
 #' @title Merge list of populations
 #'
 #' @description Rapidly merges a list of populations into a
@@ -91,33 +93,39 @@ mergePops = function(popList){
 
   #misc
   tmp = sapply(popList, function(x) length(x@misc))
-  if(all(tmp == tmp[1]) & tmp[1]>0) {
-    tmp = lapply(popList, function(x) names(x@misc))
-    allMatch = TRUE
-    if(length(tmp)>1){
-      for(i in 2:length(tmp)){
-        if(!all(tmp[[1]]==tmp[[i]])){
-          allMatch = FALSE
-          break
+  if(!all(tmp == tmp[1])) {
+    warning("number of misc elements differs - setting misc to an empty list!")
+    misc = list()
+  } else {
+    if(tmp[1]>0) {
+      tmp = lapply(popList, function(x) names(x@misc))
+      allMatch = TRUE
+      if(length(tmp)>1){
+        for(i in 2:length(tmp)){
+          if(!all(tmp[[1]]==tmp[[i]])){
+            allMatch = FALSE
+            break
+          }
         }
       }
-    }
-    if(allMatch){
-      misc = vector("list", length=length(tmp[[1]]))
-      for(i in seq_len(length(tmp[[1]]))){
-        miscTmp = lapply(popList, function(x) x@misc[[i]])
-        if (is.matrix(miscTmp[[1]])) {
-          misc[[i]] = do.call("rbind", miscTmp)
-        } else {
-          misc[[i]] = do.call("c", miscTmp)
+      if(allMatch){
+        misc = vector("list", length=length(tmp[[1]]))
+        for(i in seq_len(length(tmp[[1]]))){
+          miscTmp = lapply(popList, function(x) x@misc[[i]])
+          if (is.matrix(miscTmp[[1]])) {
+            misc[[i]] = do.call("rbind", miscTmp)
+          } else {
+            misc[[i]] = do.call("c", miscTmp)
+          }
         }
+        names(misc) = tmp[[1]]
+      }else{
+        warning("misc element names do not match - setting misc to an empty list!")
+        misc = list()
       }
-      names(misc) = tmp[[1]]
-    }else{
+    } else {
       misc = list()
     }
-  } else {
-    misc = list()
   }
 
   #sex

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -57,4 +57,27 @@ test_that("misc_and_miscPop",{
   expect_equal(popC@misc$mtLP, c(pop@misc$mtLP, pop@misc$mtLP[1]))
   expect_equal(popC@misc$mtMP, c(pop@misc$mtMP, pop@misc$mtMP[1]))
   expect_equal(popC@miscPop, list())
+
+  popA = popB = pop
+  popA@misc = pop@misc[1]
+  popB@misc = pop@misc[2]
+  expect_warning(c(popA, popB)@misc,
+                 regexp = "misc element names do not match - setting misc to an empty list!")
+
+  popA@misc = pop@misc[1:2]
+  popB@misc = pop@misc[2:1]
+  expect_warning(c(popA, popB)@misc,
+                 regexp = "misc element names do not match - setting misc to an empty list!")
+
+  popA@misc = list()
+  popB@misc = pop@misc[2:1]
+
+  popList = list(popA, popB)
+  expect_warning(c(popA, popB)@misc,
+                 regexp = "number of misc elements differs - setting misc to an empty list!")
+
+  popA@misc = pop@misc[2:1]
+  popB@misc = list()
+  expect_warning(c(popA, popB)@misc,
+                 regexp = "number of misc elements differs - setting misc to an empty list!")
 })


### PR DESCRIPTION
As described in https://github.com/gaynorr/AlphaSimR/discussions/244, we silently drop `misc` contents, which can become confusing. In this PR, I propose we throw a warning so the user is made aware why we drop the `misc` contents - either because the length differs or names don't align. This should cover most cases. I have added tests to this effect.