### PR TITLE
Fix error in RRBLUP when multiple traits are selected

### DIFF
--- a/R/selection.R
+++ b/R/selection.R
@@ -37,8 +37,8 @@ getResponse = function(pop,trait,use,simParam=NULL,...){
   }else{ # trait is not a function, so must be numeric or character
     if(is.character(trait)){ # Suspect trait is a name
       take = match(trait, simParam$traitNames)
-      if(is.na(take)){
-        stop("'",trait,"' did not match any trait names")
+      if(any(is.na(take))){
+        stop("'",trait[is.na(take)],"' did not match any trait names")
       }
       trait = take
     }


### PR DESCRIPTION
There was an error when I run the 'RRBLUP' function, I got the error message "Error in if (is.na(take)) { : the condition has length > 1". I looked deeper into the error, that actually came from the 'getResponse' function. The test at https://github.com/gaynorr/AlphaSimR/blob/master/R/selection.R#L40 was failing because it was composed of a logical vector with more than one value. This change seems to be enough to fix the error.